### PR TITLE
[simulator util] Ignore error during sim log directory deletion.

### DIFF
--- a/simulator_control/simulator_util.py
+++ b/simulator_control/simulator_util.py
@@ -158,7 +158,7 @@ class Simulator(object):
                      preexec_fn=os.setpgrp)
     # The delete command won't delete the simulator log directory.
     if os.path.exists(self.simulator_log_root_dir):
-      shutil.rmtree(self.simulator_log_root_dir)
+      shutil.rmtree(self.simulator_log_root_dir, ignore_errors=True)
     self._simulator_id = None
 
   def FetchLogToFile(self, output_file_path, start_time=None, end_time=None):


### PR DESCRIPTION
Closes https://github.com/material-foundation/xctestrunner/issues/4.

Because simulator is deleted asynchronously, the log directory can be non-empty when being deleted. This change ignores the error when it happens.