### PR TITLE
[runner] add standalone flag to enable running logic tests under xcode 11

### DIFF
--- a/test_runner/logic_test_util.py
+++ b/test_runner/logic_test_util.py
@@ -49,7 +49,7 @@ def RunLogicTestOnSim(
       simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + key] = env_vars[key]
   simctl_env_vars['NSUnbufferedIO'] = 'YES'
   command = [
-      'xcrun', 'simctl', 'spawn', sim_id,
+      'xcrun', 'simctl', 'spawn', '-s', sim_id,
       xcode_info_util.GetXctestToolPath(ios_constants.SDK.IPHONESIMULATOR)]
   if args:
     command += args

--- a/test_runner/logic_test_util.py
+++ b/test_runner/logic_test_util.py
@@ -49,7 +49,7 @@ def RunLogicTestOnSim(
       simctl_env_vars[_SIMCTL_ENV_VAR_PREFIX + key] = env_vars[key]
   simctl_env_vars['NSUnbufferedIO'] = 'YES'
   command = [
-      'xcrun', 'simctl', 'spawn', '-s', sim_id,
+      'xcrun', 'simctl', 'spawn', '--standalone', sim_id,
       xcode_info_util.GetXctestToolPath(ios_constants.SDK.IPHONESIMULATOR)]
   if args:
     command += args


### PR DESCRIPTION
Closes https://github.com/material-foundation/xctestrunner/issues/3.

Logic test can no longer be executed without the standalone flag for spawn command under XCode 
11.